### PR TITLE
fix incorrect passing of online players to addLine

### DIFF
--- a/baka_extentsions_tool.user.js
+++ b/baka_extentsions_tool.user.js
@@ -385,8 +385,9 @@
                 else
                     namesList.push(nonameCount + " безымянных сырно" +
                                    (myName === ""?" (включая тебя)":""))
+                var chatmsg = ["В чате ", ...join(namesList), "."];
                 addLine({time:d.T,
-                         message:["В чате ", ...join(namesList), "."]})
+                         message:chatmsg})
                 chat.setUsersCount(false, d.names.length)
                 break
             case "message":


### PR DESCRIPTION
http://i.imgur.com/MVhqHzf.png
For some reason passing ["В чате ", ...join(namesList), "."] directly would only pass the first element ("В чате "). Creating a separate variable solved the issue.
Chromium Version 47.0.2507.0
