### PR TITLE
dark theme fix

### DIFF
--- a/baka_extentsions_tool.user.js
+++ b/baka_extentsions_tool.user.js
@@ -1072,7 +1072,7 @@
         }
         if (document
             .querySelector('label input[onchange*=setDarkTheme]').checked)
-            bakaDarkTheme(true)
+            window.setDarkTheme(true)
     }
 
     var agar = {


### PR DESCRIPTION
Заменить вызов несуществующей bakaDarkTheme() на window.setDarkTheme().
